### PR TITLE
Update mongo-spark-connector version to 2.11:2.3.1

### DIFF
--- a/roles/spark/templates/spark-defaults.conf
+++ b/roles/spark/templates/spark-defaults.conf
@@ -28,7 +28,7 @@
 # Spark configurations for Combine
 
 spark.jars /opt/ingestion3/target/scala-2.11/ingestion3_2.11-0.0.1.jar,/opt/elasticsearch-hadoop-5.6.2/dist/elasticsearch-hadoop-5.6.2.jar,/usr/share/java/mysql.jar
-spark.jars.packages org.apache.httpcomponents:fluent-hc:4.5.2,com.databricks:spark-avro_2.11:3.2.0,com.databricks:spark-xml_2.11:0.4.1,org.mongodb.spark:mongo-spark-connector_2.11:2.1.3
+spark.jars.packages org.apache.httpcomponents:fluent-hc:4.5.2,com.databricks:spark-avro_2.11:3.2.0,com.databricks:spark-xml_2.11:0.4.1,org.mongodb.spark:mongo-spark-connector_2.11:2.3.1
 
 # MySQL JDBC driver
 spark.driver.extraClassPath /usr/share/java/mysql.jar


### PR DESCRIPTION
As per conversation in the Combine Slack channel:

The version of mongo-spark-connector needs to be raised to work with Spark 2.3.2, which is the current default in `group_vars/all.yml`